### PR TITLE
feat: Add Threads link and update icon hover color

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,16 +64,20 @@
                 "Override Project está naciendo, el universo móvil se está alineando."
             </p>
             <div class="mt-12 flex justify-center space-x-6">
-                <a href="https://twitter.com/OverridePjt" target="_blank" class="text-gray-400 hover:text-white transform transition-transform duration-300 hover:scale-110">
+                <a href="https://twitter.com/OverridePjt" target="_blank" class="text-gray-400 hover:text-purple-600 transform transition-transform duration-300 hover:scale-110">
                     <i class="fa-brands fa-x-twitter fa-2x"></i>
                 </a>
-                <a href="https://www.instagram.com/overrideproject" target="_blank" class="text-gray-400 hover:text-white transform transition-transform duration-300 hover:scale-110">
+                <a href="https://www.instagram.com/overrideproject" target="_blank" class="text-gray-400 hover:text-purple-600 transform transition-transform duration-300 hover:scale-110">
                     <i class="fa-brands fa-instagram fa-2x"></i>
                 </a>
-                <a href="https://www.facebook.com/profile.php?id=61579024295567" target="_blank" class="text-gray-400 hover:text-white transform transition-transform duration-300 hover:scale-110">
+                <!-- TODO: Add correct Threads URL -->
+                <a href="https://www.threads.net/@overrideproject" target="_blank" class="text-gray-400 hover:text-purple-600 transform transition-transform duration-300 hover:scale-110">
+                    <i class="fa-brands fa-threads fa-2x"></i>
+                </a>
+                <a href="https://www.facebook.com/profile.php?id=61579024295567" target="_blank" class="text-gray-400 hover:text-purple-600 transform transition-transform duration-300 hover:scale-110">
                     <i class="fa-brands fa-facebook fa-2x"></i>
                 </a>
-                <a href="https://discord.gg/ZsbQDWPy" target="_blank" class="text-gray-400 hover:text-white transform transition-transform duration-300 hover:scale-110">
+                <a href="https://discord.gg/ZsbQDWPy" target="_blank" class="text-gray-400 hover:text-purple-600 transform transition-transform duration-300 hover:scale-110">
                     <i class="fa-brands fa-discord fa-2x"></i>
                 </a>
             </div>


### PR DESCRIPTION
This change adds a new social media link for Threads and updates the hover color for all social media icons to purple, matching the site's color scheme.