### PR TITLE
Fix: Configure project for GitHub Pages deployment and workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,10 +16,10 @@ jobs:
       - run: npm install
       - run: npm run build
       - name: Copy index.html to 404.html for Vue Router
-        run: cp dist/index.html dist/404.html
+        run: cp docs/index.html docs/404.html
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: dist
+          path: docs
 
   deploy:
     needs: build


### PR DESCRIPTION
This commit resolves issues preventing the application from deploying and running correctly on GitHub Pages with a custom domain.

The following changes were made:
- Updated `vite.config.js` to set the `base` URL to `/` and the build output directory to `docs`.
- Created a `.nojekyll` file to prevent GitHub Pages from running its default Jekyll build process.
- Updated the `.github/workflows/deploy.yml` file to use the `docs` directory instead of `dist` for the build artifact, aligning it with the Vite configuration.
- Created a comprehensive `.gitignore` file to exclude unnecessary files from version control.