### PR TITLE
feat: Add social media links to documentation footer

### DIFF
--- a/src/components/DocsFooter.vue
+++ b/src/components/DocsFooter.vue
@@ -1,5 +1,6 @@
 <template>
   <footer id="docs-footer" class="mt-12 pt-8 border-t border-gray-200 dark:border-gray-700 text-sm text-gray-500 dark:text-gray-400">
+    <SocialLinks class="mb-4" />
     <p><span data-i18n="last_updated">Last Updated</span>: <span>{{ lastUpdated }}</span></p>
     <p>Version: 1.0.0</p>
   </footer>
@@ -8,6 +9,7 @@
 <script setup>
 import { ref, onMounted } from 'vue';
 import { store } from '../store';
+import SocialLinks from './SocialLinks.vue';
 
 const lastUpdated = ref('');
 

--- a/src/components/GlobalFooter.vue
+++ b/src/components/GlobalFooter.vue
@@ -1,9 +1,10 @@
 <template>
   <footer id="global-footer" class="bg-gray-200 dark:bg-gray-800 text-center p-4 text-sm text-gray-600 dark:text-gray-400 flex-shrink-0">
+    <SocialLinks class="mb-4" />
     <p>&copy; 2024 Override Project. All Rights Reserved.</p>
   </footer>
 </template>
 
 <script setup>
-// No script needed for this simple component
+import SocialLinks from './SocialLinks.vue';
 </script>

--- a/src/components/SocialLinks.vue
+++ b/src/components/SocialLinks.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="flex justify-center space-x-6">
+    <a href="https://twitter.com/OverridePjt" target="_blank" class="text-gray-400 hover:text-purple-600 transform transition-transform duration-300 hover:scale-110">
+        <i class="fa-brands fa-x-twitter fa-2x"></i>
+    </a>
+    <a href="https://www.instagram.com/overrideproject" target="_blank" class="text-gray-400 hover:text-purple-600 transform transition-transform duration-300 hover:scale-110">
+        <i class="fa-brands fa-instagram fa-2x"></i>
+    </a>
+    <a href="https://www.threads.net/@overrideproject" target="_blank" class="text-gray-400 hover:text-purple-600 transform transition-transform duration-300 hover:scale-110">
+        <i class="fa-brands fa-threads fa-2x"></i>
+    </a>
+    <a href="https://www.facebook.com/profile.php?id=61579024295567" target="_blank" class="text-gray-400 hover:text-purple-600 transform transition-transform duration-300 hover:scale-110">
+        <i class="fa-brands fa-facebook fa-2x"></i>
+    </a>
+    <a href="https://discord.gg/ZsbQDWPy" target="_blank" class="text-gray-400 hover:text-purple-600 transform transition-transform duration-300 hover:scale-110">
+        <i class="fa-brands fa-discord fa-2x"></i>
+    </a>
+  </div>
+</template>
+
+<script setup>
+// No script needed for this simple component
+</script>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -7,23 +7,6 @@
       <p class="text-lg md:text-xl text-gray-600 dark:text-gray-300 mb-8">
         {{ store.translations.subtitle || '...' }}
       </p>
-       <div class="mt-12 flex justify-center space-x-6">
-          <a href="https://twitter.com/OverridePjt" target="_blank" class="text-gray-400 hover:text-purple-600 transform transition-transform duration-300 hover:scale-110">
-              <i class="fa-brands fa-x-twitter fa-2x"></i>
-          </a>
-          <a href="https://www.instagram.com/overrideproject" target="_blank" class="text-gray-400 hover:text-purple-600 transform transition-transform duration-300 hover:scale-110">
-              <i class="fa-brands fa-instagram fa-2x"></i>
-          </a>
-          <a href="https://www.threads.net/@overrideproject" target="_blank" class="text-gray-400 hover:text-purple-600 transform transition-transform duration-300 hover:scale-110">
-              <i class="fa-brands fa-threads fa-2x"></i>
-          </a>
-          <a href="https://www.facebook.com/profile.php?id=61579024295567" target="_blank" class="text-gray-400 hover:text-purple-600 transform transition-transform duration-300 hover:scale-110">
-              <i class="fa-brands fa-facebook fa-2x"></i>
-          </a>
-          <a href="https://discord.gg/ZsbQDWPy" target="_blank" class="text-gray-400 hover:text-purple-600 transform transition-transform duration-300 hover:scale-110">
-              <i class="fa-brands fa-discord fa-2x"></i>
-          </a>
-      </div>
     </div>
   </main>
 </template>


### PR DESCRIPTION
This commit introduces a reusable `SocialLinks.vue` component to display social media icons.

- Extracts the social media links from `HomeView.vue` into the new `SocialLinks.vue` component.
- Integrates the `SocialLinks.vue` component into `GlobalFooter.vue` for the home page and `DocsFooter.vue` for the documentation pages.
- Adjusts styling to ensure consistent layout and spacing in the footers.